### PR TITLE
name must contain region to support multi-region deployments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,8 +43,9 @@ locals {
 
   # If standard output length if greater than maximum length provided by user, then output for the user is created using maximum length specified by the user.
   # For that strip off region from the output. Also restrict the logical_product_name so that total length of the output is same as maximum length.
-  recommended_per_length_restriction = length(local.standard) > var.maximum_length ? format("%s%s%s%s%s",
+  recommended_per_length_restriction = length(local.standard) > var.maximum_length ? format("%s%s%s%s%s%s",
     substr(local.logical_product_name, 0, var.maximum_length - local.length_of_variable_list_without_product_name),
+    local.region,
     local.class_env,
     local.instance_env,
     local.cloud_resource_type,

--- a/tests/post_deploy_functional/resourcename_test.go
+++ b/tests/post_deploy_functional/resourcename_test.go
@@ -102,7 +102,7 @@ func TestTerraformResourcenameExample_minLength(t *testing.T) {
 
 	recommended_per_length_restriction := terraform.Output(t, terraformOptions, "recommended_per_length_restriction")
 
-	assert.Equal(t, recommended_per_length_restriction, "invoicidev100sa001")
+	assert.Equal(t, recommended_per_length_restriction, "invoiciwestusdev100sa001")
 }
 
 func TestTerraformResourcenameExample_maxLength(t *testing.T) {


### PR DESCRIPTION
In case of generating the names for type - recommended_per_length_restriction, the resource name must contain the region in it, in order to support multi-region deployments. Else, same resource name is generated for resources in multiple region which throws error.

This is particularly useful for azure storage account and key-vault names where the length restriction is 24.

For e.g. two storage accounts in eastus and westus should be named demobackeneusdev000sa000 and demobackenwusdev000sa000 respectively. Earlier code would generate the same name demobackendev000sa000 for both (as it was removing the region from the name to fit in to the length restriction).